### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -129,7 +129,7 @@ install_deps() {
 
 install_all() {
     install_deps
-    pip install configparser --user
+    export LC_ALL=C && pip install configparser --user
     python_env=$(which python)
     py_version=$($python_env -V 2>&1 | awk {'print $2'} | awk -F. {' print $1 '})
     py_pip=$(pip -V 2>&1 | awk 'END {print $6}' | sed 's/)$//' | awk -F. '{print $1}')


### PR DESCRIPTION
Modify the system language setting before installing configparser, otherwise the subsequent script will not find the configparser whatever it's python 2 or 3 or both installed in the system.