### PR TITLE
fix configparser import error && format config.py with autopep8

### DIFF
--- a/pys/build/config.py
+++ b/pys/build/config.py
@@ -22,7 +22,10 @@ Returns:
 """
 import os
 import shutil
-import configparser
+try:
+    import configparser
+except Exception:
+    from six.moves import configparser
 import codecs
 from pys.tool import utils
 from pys import path
@@ -187,16 +190,19 @@ def build_config_ini(_data_dir):
             utils.delete_data(package_dir)
             raise MCError(
                 ' open config.ini file failed, exception is %s' % build_exp)
-        # write p2pip:port into config.ini 
+        # write p2pip:port into config.ini
         for ip_idx, set_item in enumerate(p2p_ip):
-            fin_p2p_ip.append("{}:{}".format(set_item, p2p_listen_port[ip_idx]))
+            fin_p2p_ip.append("{}:{}".format(
+                set_item, p2p_listen_port[ip_idx]))
         fin_p2p_ip = list(set(fin_p2p_ip))
         for index, p2p_section in enumerate(fin_p2p_ip):
             node_cfg.set("p2p", "node.{}".format(index),
                          '{}'.format(p2p_section))
-            node_cfg.set('certificate_whitelist', '; cal.0 should be nodeid, nodeid\'s length is 128')
+            node_cfg.set('certificate_whitelist',
+                         '; cal.0 should be nodeid, nodeid\'s length is 128')
             node_cfg.set('certificate_whitelist', ';cal.0=')
-            node_cfg.set('certificate_blacklist', '; crl.0 should be nodeid, nodeid\'s length is 128')
+            node_cfg.set('certificate_blacklist',
+                         '; crl.0 should be nodeid, nodeid\'s length is 128')
             node_cfg.set('certificate_blacklist', ';crl.0=')
         with open('{}/config.ini'.format(node_dir), 'w') as config_file:
             node_cfg.write(config_file)
@@ -402,9 +408,11 @@ def concatenate_cfg(cfg_file, cfg_file_get):
     LOGGER.info("final node ip is %s!", p2p_send_ip)
     for ip_idx, p2p_ip in enumerate(p2p_send_ip):
         p2p_cfg.set("p2p", "node.{}".format(ip_idx), p2p_ip)
-    p2p_cfg.set('certificate_whitelist', '; cal.0 should be nodeid, nodeid\'s length is 128')
+    p2p_cfg.set('certificate_whitelist',
+                '; cal.0 should be nodeid, nodeid\'s length is 128')
     p2p_cfg.set('certificate_whitelist', ';cal.0=')
-    p2p_cfg.set('certificate_blacklist', '; crl.0 should be nodeid, nodeid\'s length is 128')
+    p2p_cfg.set('certificate_blacklist',
+                '; crl.0 should be nodeid, nodeid\'s length is 128')
     p2p_cfg.set('certificate_blacklist', ';crl.0=')
     with open(data, 'w') as config_file:
         p2p_cfg.write(config_file)
@@ -457,9 +465,11 @@ def merge_cfg(p2p_list, cfg_file):
     LOGGER.info("final node ip is %s!", p2p_send)
     for ip_idx, p2p_ip in enumerate(p2p_send):
         p2p_cfg.set("p2p", "node.{}".format(ip_idx), p2p_ip)
-    p2p_cfg.set('certificate_whitelist', '; cal.0 should be nodeid, nodeid\'s length is 128')
+    p2p_cfg.set('certificate_whitelist',
+                '; cal.0 should be nodeid, nodeid\'s length is 128')
     p2p_cfg.set('certificate_whitelist', ';cal.0=')
-    p2p_cfg.set('certificate_blacklist', '; crl.0 should be nodeid, nodeid\'s length is 128')
+    p2p_cfg.set('certificate_blacklist',
+                '; crl.0 should be nodeid, nodeid\'s length is 128')
     p2p_cfg.set('certificate_blacklist', ';crl.0=')
     with open(data, 'w') as config_file:
         p2p_cfg.write(config_file)
@@ -520,14 +530,16 @@ def add_group(_group, _node):
         utils.file_must_not_exists('{}/conf/{}'.format(_node, file_name))
         shutil.copyfile(data_path, '{}/conf/{}'.format(_node, file_name))
         shutil.copyfile('{}/tpl/group.i.ini'.format(path.get_path()),
-                    '{}/conf/group.{}.ini'.format(_node, group_id))
+                        '{}/conf/group.{}.ini'.format(_node, group_id))
     else:
         node_send = utils.get_all_nodes_dir(_node)
         for node_file in node_send:
-            utils.file_must_not_exists('{}/conf/{}'.format(node_file, file_name))
-            shutil.copyfile(data_path, '{}/conf/{}'.format(node_file, file_name))
+            utils.file_must_not_exists(
+                '{}/conf/{}'.format(node_file, file_name))
+            shutil.copyfile(
+                data_path, '{}/conf/{}'.format(node_file, file_name))
             shutil.copyfile('{}/tpl/group.i.ini'.format(path.get_path()),
-                        '{}/conf/group.{}.ini'.format(node_file, group_id))
+                            '{}/conf/group.{}.ini'.format(node_file, group_id))
 
 
 def get_console_file(_file):

--- a/pys/build/group.py
+++ b/pys/build/group.py
@@ -13,8 +13,10 @@ Raises:
 """
 import os
 import shutil
-import configparser
-
+try:
+    import configparser
+except Exception:
+    from six.moves import configparser
 from pys import path
 from pys.log import LOGGER, CONSOLER
 from pys.error.exp import MCError
@@ -56,6 +58,7 @@ def create_group_genesis(data_dir='{}/meta'.format(path.get_path())):
             % (package_dir, group_id, time_stamp))
     # CONSOLER.info('generate %s/group.%s.ini', package_dir, group_id)
     group_cfg = configparser.ConfigParser(allow_no_value=True)
+    sealersNum = 0
     with open('{}/group.{}.genesis'.format(package_dir, group_id), 'r') as config_file:
         group_cfg.readfp(config_file)
     for node_idx, _in in enumerate(p2p_ip):
@@ -81,13 +84,15 @@ def create_group_genesis(data_dir='{}/meta'.format(path.get_path())):
                             p2p_listen_port[node_idx])
                 LOGGER.info("nodeid -> %s", node_id)
                 group_cfg.set("consensus", "node.{}".format(node_idx), node_id)
+            sealersNum += 1
         except Exception as group_exp:
             LOGGER.error(
                 'create group genesis failed! exception is %s', group_exp)
             raise MCError(
                 'create group genesis failed! exception is %s' % group_exp)
         group_cfg.set("group", "id", group_id)
-        group_cfg.set("group", "timestamp", time_stamp)
+        group_cfg.set("group", "timestamp", str(time_stamp))
+        group_cfg.set("consensus", "epoch_sealer_num", str(sealersNum))
     with open('{}/group.{}.genesis'.format(package_dir, group_id), 'w') as config_file:
         group_cfg.write(config_file)
     shutil.copy('{}/group.{}.genesis'.format(package_dir, group_id),

--- a/pys/conf/mconf.py
+++ b/pys/conf/mconf.py
@@ -9,7 +9,10 @@ Returns:
     [bool] -- [true or false]
 """
 
-import configparser
+try:
+    import configparser
+except Exception:
+    from six.moves import configparser
 import codecs
 from pys.tool import utils
 # from pys import path

--- a/pys/conf/mgroup.py
+++ b/pys/conf/mgroup.py
@@ -10,8 +10,10 @@ Raises:
 Returns:
     [bool] -- [true or false]
 """
-
-import configparser
+try:
+    import configparser
+except Exception:
+    from six.moves import configparser
 import codecs
 from pys.tool import utils
 from pys.log import LOGGER
@@ -73,7 +75,8 @@ def parser(mgroup):
     LOGGER.info('group_genesis.ini is %s', mgroup)
     # resolve configuration
     if not utils.valid_string(mgroup):
-        LOGGER.error(' group_genesis.ini not invalid path, group_genesis.ini is %s', mgroup)
+        LOGGER.error(
+            ' group_genesis.ini not invalid path, group_genesis.ini is %s', mgroup)
         raise MCError(
             ' group_genesis.ini not invalid path, group_genesis.ini is %s' % mgroup)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+six
 configparser

--- a/tpl/config.ini
+++ b/tpl/config.ini
@@ -1,49 +1,49 @@
 [rpc]
-    ; channel listen ip
-    channel_listen_ip=0.0.0.0
-    ; rpc listen ip
-    jsonrpc_listen_ip=127.0.0.1
-    ; channelserver listen port
-    channel_listen_port=20200
-    ; jsonrpc listen port
-    jsonrpc_listen_port=8545
-[p2p]
-    ; p2p listen ip
-    listen_ip=0.0.0.0
-    ; p2p listen port
-    listen_port=30300
-    ; nodes to connect
-    node.0=
+; channel listen ip
+channel_listen_ip=0.0.0.0
+; rpc listen ip
+jsonrpc_listen_ip=127.0.0.1
+; channelserver listen port
+channel_listen_port=20200
+; jsonrpc listen port
+jsonrpc_listen_port=8545
 
-    ;enable/disable network compress
-    ;enable_compress=true
+[p2p]
+; p2p listen ip
+listen_ip=0.0.0.0
+; p2p listen port
+listen_port=30300
+; nodes to connect
+node.0=
+;enable/disable network compress
+;enable_compress=true
     
 ;certificate rejected list
 [certificate_blacklist]
-    ; crl.0 should be nodeid, nodeid's length is 128
-    ;crl.0=
+; crl.0 should be nodeid, nodeid's length is 128
+;crl.0=
 
 ;certificate whitelist list
 [certificate_whitelist]		
-    ; cal.0 should be nodeid, nodeid's length is 128 
-    ;cal.0=
+; cal.0 should be nodeid, nodeid's length is 128 
+;cal.0=
 
 ;group configurations
 ;WARNING: group 0 is forbided
 [group]
-    group_data_path=data/
-    group_config_path=conf/
+group_data_path=data/
+group_config_path=conf/
 
 ;certificate configuration
 [network_security]
-    ; directory the certificates located in
-    data_path=conf/
-    ; the node private key file
-    key=node.key
-    ; the node certificate file
-    cert=node.crt
-    ; the ca certificate file
-    ca_cert=ca.crt
+; directory the certificates located in
+data_path=conf/
+; the node private key file
+key=node.key
+; the node certificate file
+cert=node.crt
+; the ca certificate file
+ca_cert=ca.crt
 
 ; storage security releated configurations
 [storage_security]
@@ -55,20 +55,22 @@ key_manager_port=
 cipher_data_key=
 
 [chain]
-    id=1
+id=1
+
 [compatibility]
-    supported_version=2.2.0
+supported_version=2.3.0
+
 ;log configurations
 [log]
-    enable=true
-    ; the directory of the log
-    log_path=./log
-    ; info debug trace 
-    level=info
-    ; MB
-    max_log_file_size=200
-    ; control log auto_flush
-    flush=true
-    ; easylog config
-    log_flush_threshold=100
+enable=true
+; the directory of the log
+log_path=./log
+; info debug trace 
+level=info
+; MB
+max_log_file_size=200
+; control log auto_flush
+flush=true
+; easylog config
+log_flush_threshold=100
     

--- a/tpl/config.ini.gm
+++ b/tpl/config.ini.gm
@@ -1,49 +1,49 @@
 [rpc]
-    ; channel listen ip
-    channel_listen_ip=0.0.0.0
-    ; rpc listen ip
-    jsonrpc_listen_ip=127.0.0.1
-    ; channelserver listen port
-    channel_listen_port=20200
-    ; jsonrpc listen port
-    jsonrpc_listen_port=8545
-[p2p]
-    ; p2p listen ip
-    listen_ip=0.0.0.0
-    ; p2p listen port
-    listen_port=30300
-    ; nodes to connect
-    node.0=
+; channel listen ip
+channel_listen_ip=0.0.0.0
+; rpc listen ip
+jsonrpc_listen_ip=127.0.0.1
+; channelserver listen port
+channel_listen_port=20200
+; jsonrpc listen port
+jsonrpc_listen_port=8545
 
-    ;enable/disable network compress
-    ;enable_compress=true
+[p2p]
+; p2p listen ip
+listen_ip=0.0.0.0
+; p2p listen port
+listen_port=30300
+; nodes to connect
+node.0=
+;enable/disable network compress
+;enable_compress=true
     
 ;certificate rejected list
 [certificate_blacklist]
-    ; crl.0 should be nodeid, nodeid's length is 128
-    ;crl.0=
+; crl.0 should be nodeid, nodeid's length is 128
+;crl.0=
 
 ;certificate whitelist list
 [certificate_whitelist]		
-    ; cal.0 should be nodeid, nodeid's length is 128 
-    ;cal.0=
+; cal.0 should be nodeid, nodeid's length is 128 
+;cal.0=
 
 ;group configurations
 ;WARNING: group 0 is forbided
 [group]
-    group_data_path=data/
-    group_config_path=conf/
+group_data_path=data/
+group_config_path=conf/
 
 ;certificate configuration
 [network_security]
-    ; directory the certificates located in
-    data_path=conf/
-    ; the node private key file
-    key=gmnode.key
-    ; the node certificate file
-    cert=gmnode.crt
-    ; the ca certificate file
-    ca_cert=gmca.crt
+; directory the certificates located in
+data_path=conf/
+; the node private key file
+key=gmnode.key
+; the node certificate file
+cert=gmnode.crt
+; the ca certificate file
+ca_cert=gmca.crt
 
 ; storage security releated configurations
 [storage_security]
@@ -55,20 +55,22 @@ key_manager_port=
 cipher_data_key=
 
 [chain]
-    id=1
+id=1
+
 [compatibility]
-    supported_version=2.2.0
+supported_version=2.2.0
+
 ;log configurations
 [log]
-    enable=true
-    ; the directory of the log
-    log_path=./log
-    ; info debug trace 
-    level=info
-    ; MB
-    max_log_file_size=200
-    ; control log auto_flush
-    flush=true
-    ; easylog config
-    log_flush_threshold=100
+enable=true
+; the directory of the log
+log_path=./log
+; info debug trace 
+level=info
+; MB
+max_log_file_size=200
+; control log auto_flush
+flush=true
+; easylog config
+log_flush_threshold=100
     

--- a/tpl/group.i.genesis
+++ b/tpl/group.i.genesis
@@ -3,21 +3,21 @@ id=${index}
 timestamp=${time_stamp}
 
 [consensus]
-    ; consensus algorithm now support PBFT(consensus_type=pbft), Raft(consensus_type=raft)
-    ; and rpbft(consensus_type=rpbft)
-    consensus_type=pbft
-    ; the max number of transactions of a block
-    max_trans_num=1000
-    ; rpbft related configuration
-    ; the sealers num of each consensus epoch
-    epoch_sealer_num=${sealer_size}
-    ; the number of generated blocks each epoch
-    epoch_block_num=1000
-    node.0=
+; consensus algorithm now support PBFT(consensus_type=pbft), Raft(consensus_type=raft)
+; and rpbft(consensus_type=rpbft)
+consensus_type=pbft
+; the max number of transactions of a block
+max_trans_num=1000
+; rpbft related configuration
+; the sealers num of each consensus epoch
+epoch_sealer_num=${sealer_size}
+; the number of generated blocks each epoch
+epoch_block_num=1000
+node.0=
 
 [state]
-    type=storage
+type=storage
 
 ; tx gas limit
 [tx]
-    gas_limit=300000000
+gas_limit=300000000

--- a/tpl/group.i.ini
+++ b/tpl/group.i.ini
@@ -1,56 +1,59 @@
 [consensus]
-    ; the ttl for broadcasting pbft message
-    ttl=2
-    ; min block generation time(ms), the max block generation time is 1000 ms
-    min_block_generation_time=500
-    ;enable_dynamic_block_size=true
-    enable_ttl_optimization=true
-    enable_prepare_with_txsHash=true
-    ; The following is the relevant configuration of rpbft
-    ; set true to enable broadcast prepare request by tree
-    broadcast_prepare_by_tree=true
-    ; percent of nodes that broadcast prepare status to, must be between 25 and 100
-    prepare_status_broadcast_percent=33
-    ; max wait time before request missed transactions, ms, must be between 5ms and 1000ms
-    max_request_missedTxs_waitTime=100
-    ; maximum wait time before requesting a prepare, ms, must be between 10ms and 1000ms
-    max_request_prepare_waitTime=100
+; the ttl for broadcasting pbft message
+ttl=2
+; min block generation time(ms), the max block generation time is 1000 ms
+min_block_generation_time=500
+;enable_dynamic_block_size=true
+enable_ttl_optimization=true
+enable_prepare_with_txsHash=true
+; The following is the relevant configuration of rpbft
+; set true to enable broadcast prepare request by tree
+broadcast_prepare_by_tree=true
+; percent of nodes that broadcast prepare status to, must be between 25 and 100
+prepare_status_broadcast_percent=33
+; max wait time before request missed transactions, ms, must be between 5ms and 1000ms
+max_request_missedTxs_waitTime=100
+; maximum wait time before requesting a prepare, ms, must be between 10ms and 1000ms
+max_request_prepare_waitTime=100
+
  [storage]
-    ; storage db type, rocksdb / mysql / scalable, rocksdb is recommended
-    type=rocksdb
-    ; set true to turn on binary log
-    binary_log=false
-    ; scroll_threshold=scroll_threshold_multiple*1000, only for scalable
-    scroll_threshold_multiple=2
-    ; set fasle to disable CachedStorage
-    cached_storage=true
-    ; max cache memeory, MB
-    max_capacity=32
-    max_forward_block=10
-    ; only for external, deprecated in v2.3.0
-    max_retry=60
-    topic=DB
-    ; only for mysql
-    db_ip=127.0.0.1
-    db_port=3306
-    db_username=
-    db_passwd=
-    db_name=
+; storage db type, rocksdb / mysql / scalable, rocksdb is recommended
+type=rocksdb
+; set true to turn on binary log
+binary_log=false
+; scroll_threshold=scroll_threshold_multiple*1000, only for scalable
+scroll_threshold_multiple=2
+; set fasle to disable CachedStorage
+cached_storage=true
+; max cache memeory, MB
+max_capacity=32
+max_forward_block=10
+; only for external, deprecated in v2.3.0
+max_retry=60
+topic=DB
+; only for mysql
+db_ip=127.0.0.1
+db_port=3306
+db_username=
+db_passwd=
+db_name=
+
 ; txpool limit
 [tx_pool]
-    limit=150000
+limit=150000
+
 [sync]
-    ; max memory size used for block sync, must >= 32MB
-    max_block_sync_memory_size=512
-    idle_wait_ms=200
-    ; send block status by tree-topology, only supported when use pbft
-    sync_block_by_tree=true
-    ; send transaction by tree-topology, only supported when use pbft
-    ; recommend to use when deploy many consensus nodes
-    send_txs_by_tree=true
-    ; must between 1000 to 3000
-    ; only enabled when sync_by_tree is true
-    gossip_interval_ms=1000
-    gossip_peers_number=3
-    ; max number of nodes that broadcast txs status to, recommended less than 5 
-    txs_max_gossip_peers_num=5
+; max memory size used for block sync, must >= 32MB
+max_block_sync_memory_size=512
+idle_wait_ms=200
+; send block status by tree-topology, only supported when use pbft
+sync_block_by_tree=true
+; send transaction by tree-topology, only supported when use pbft
+; recommend to use when deploy many consensus nodes
+send_txs_by_tree=true
+; must between 1000 to 3000
+; only enabled when sync_by_tree is true
+gossip_interval_ms=1000
+gossip_peers_number=3
+; max number of nodes that broadcast txs status to, recommended less than 5 
+txs_max_gossip_peers_num=5


### PR DESCRIPTION
Note: 
six.configparser has a flaw: the ini configuration type must be written at the top of the box, otherwise it will parse errors