### PR TITLE
generator add new command: generate_agency_certificate_key_csr and sign_agency_certificate

### DIFF
--- a/generator
+++ b/generator
@@ -203,9 +203,9 @@ def usage():
         build.get_sdk(args.get_sdk_file[0])
     elif args.generate_agency_certificate_key_csr:
         CONSOLER.info(' Agency cert key&csr begin.')
+        CONSOLER.info(args.generate_agency_certificate_key_csr)
         agency_dir = args.generate_agency_certificate[0]
         agency_name = args.generate_agency_certificate[1]
-        CONSOLER.info(agency_dir + agency_name)
         ca.generator_agent_key_csr(agency_dir, agency_name)
         CONSOLER.info(' Agency cert key&csr end.')
     else:

--- a/generator
+++ b/generator
@@ -197,6 +197,12 @@ def usage():
         build.build_console(args.download_console[0])
     elif args.get_sdk_file:
         build.get_sdk(args.get_sdk_file[0])
+    elif args.generate_agency_certificate_key_csr:
+        CONSOLER.info(' Agency cert key&csr begin.')
+        agency_dir = args.generate_agency_certificate[0]
+        agency_name = args.generate_agency_certificate[1]
+        ca.generator_agent_key_csr(agency_dir, agency_name)
+        CONSOLER.info(' Agency cert key&csr end.')
     else:
         console_error(
             ' Invalid operation,  \"generator -h\" can be used to show detailed usage. ')

--- a/generator
+++ b/generator
@@ -99,6 +99,10 @@ def usage():
                              help='get sdk file')
     tools_group.add_argument('--console_version', nargs=1,
                              help='specify the downloaded console version')
+    tools_group.add_argument('--generate_agency_certificate_key_csr', nargs=2, metavar=('agency_dir',
+                                                                                        'agency_name'),
+                             help='generate agency certificate key and csr file')
+
     args = parser.parse_args()
     if args.use_guomi:
         CONSOLER.info('======= BUILD_GM ============= ON =======')

--- a/generator
+++ b/generator
@@ -203,9 +203,8 @@ def usage():
         build.get_sdk(args.get_sdk_file[0])
     elif args.generate_agency_certificate_key_csr:
         CONSOLER.info(' Agency cert key&csr begin.')
-        agency_dir = args.generate_agency_certificate[0]
-        agency_name = args.generate_agency_certificate[1]
-        CONSOLER.info(args.generate_agency_certificate_key_csr)
+        agency_dir = args.generate_agency_certificate_key_csr[0]
+        agency_name = args.generate_agency_certificate_key_csr[1]
         ca.generator_agent_key_csr(agency_dir, agency_name)
         CONSOLER.info(' Agency cert key&csr end.')
     else:

--- a/generator
+++ b/generator
@@ -203,9 +203,9 @@ def usage():
         build.get_sdk(args.get_sdk_file[0])
     elif args.generate_agency_certificate_key_csr:
         CONSOLER.info(' Agency cert key&csr begin.')
-        CONSOLER.info(args.generate_agency_certificate_key_csr)
         agency_dir = args.generate_agency_certificate[0]
         agency_name = args.generate_agency_certificate[1]
+        CONSOLER.info(args.generate_agency_certificate_key_csr)
         ca.generator_agent_key_csr(agency_dir, agency_name)
         CONSOLER.info(' Agency cert key&csr end.')
     else:

--- a/generator
+++ b/generator
@@ -102,6 +102,9 @@ def usage():
     tools_group.add_argument('--generate_agency_certificate_key_csr', nargs=2, metavar=('agency_dir',
                                                                                         'agency_name'),
                              help='generate agency certificate key and csr file')
+    tools_group.add_argument('--sign_agency_certificate', nargs=2, metavar=('chain_dir',
+                                                                            'agency_path'),
+                             help='sign agency certificate')
 
     args = parser.parse_args()
     if args.use_guomi:
@@ -207,6 +210,12 @@ def usage():
         agency_name = args.generate_agency_certificate_key_csr[1]
         ca.generator_agent_key_csr(agency_dir, agency_name)
         CONSOLER.info(' Agency cert key&csr end.')
+    elif args.sign_agency_certificate:
+        CONSOLER.info(' Sign agency cert begin.')
+        chain_dir = args.sign_agency_certificate[0]
+        agency_path = args.sign_agency_certificate[1]
+        ca.sign_agent_cert(chain_dir, agency_path)
+        CONSOLER.info(' Sign agency cert end.')
     else:
         console_error(
             ' Invalid operation,  \"generator -h\" can be used to show detailed usage. ')

--- a/generator
+++ b/generator
@@ -205,6 +205,7 @@ def usage():
         CONSOLER.info(' Agency cert key&csr begin.')
         agency_dir = args.generate_agency_certificate[0]
         agency_name = args.generate_agency_certificate[1]
+        CONSOLER.info(agency_dir + agency_name)
         ca.generator_agent_key_csr(agency_dir, agency_name)
         CONSOLER.info(' Agency cert key&csr end.')
     else:

--- a/pys/tool/ca.py
+++ b/pys/tool/ca.py
@@ -113,15 +113,15 @@ def generator_node_ca(_dir, agent, node):
             os.chdir('{}/scripts/gm/'.format(path.get_path()))
             (status, result) = utils.getstatusoutput('./cts.sh'
                                                      ' gen_node_cert {} {}/{}'
-                                                     .format(
-                                                         agent, node_dir, node))
+            .format(
+                agent, node_dir, node))
             os.chdir('{}'.format(path.get_path()))
         else:
             os.chdir('{}/scripts/'.format(path.get_path()))
             (status, result) = utils.getstatusoutput('./cts.sh'
                                                      ' gen_node_cert {} {}/{}'
-                                                     .format(
-                                                         agent, node_dir, node))
+            .format(
+                agent, node_dir, node))
             os.chdir('{}'.format(path.get_path()))
         if not bool(status):
             LOGGER.info(' Generate %s cert successful! dir is %s/%s.',
@@ -130,13 +130,13 @@ def generator_node_ca(_dir, agent, node):
             if utils.Status.gm_option:
                 (status, result) = utils.getstatusoutput('cat {}/{}/gmagency.crt '
                                                          '>> {}/{}/gmnode.crt'.format(
-                                                             _dir, node, _dir, node))
+                    _dir, node, _dir, node))
                 os.remove('{}/{}/gmagency.crt'.format(_dir, node))
                 os.remove('{}/{}/gmnode.serial'.format(_dir, node))
             else:
                 (status, result) = utils.getstatusoutput('cat {}/{}/agency.crt '
                                                          '>> {}/{}/node.crt'.format(
-                                                             _dir, node, _dir, node))
+                    _dir, node, _dir, node))
                 os.remove('{}/{}/agency.crt'.format(_dir, node))
                 os.remove('{}/{}/node.ca'.format(_dir, node))
                 os.remove('{}/{}/node.json'.format(_dir, node))
@@ -178,27 +178,28 @@ def generator_sdk_ca(_dir, agent):
             generator_node_ca(sdk_dir, agency_dir, 'sdk')
             os.remove('{}/sdk/node.nodeid'.format(sdk_dir))
             shutil.copyfile('{}/sdk/node.crt'.format(sdk_dir),
-                    '{}/sdk/sdk.crt'.format(sdk_dir))
+                            '{}/sdk/sdk.crt'.format(sdk_dir))
             shutil.copyfile('{}/sdk/node.key'.format(sdk_dir),
-                    '{}/sdk/sdk.key'.format(sdk_dir))
+                            '{}/sdk/sdk.key'.format(sdk_dir))
             utils.set_gm()
         generator_node_ca('{}/sdk'.format(sdk_dir), agency_dir, 'gm')
         os.remove('{}/sdk/gm/gmnode.nodeid'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmnode.crt'.format(sdk_dir),
-                '{}/sdk/gm/gmsdk.crt'.format(sdk_dir))
+                        '{}/sdk/gm/gmsdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmnode.key'.format(sdk_dir),
-                '{}/sdk/gm/gmsdk.key'.format(sdk_dir))
+                        '{}/sdk/gm/gmsdk.key'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmennode.crt'.format(sdk_dir),
-                '{}/sdk/gm/gmensdk.crt'.format(sdk_dir))
+                        '{}/sdk/gm/gmensdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmennode.key'.format(sdk_dir),
-                '{}/sdk/gm/gmensdk.key'.format(sdk_dir))
+                        '{}/sdk/gm/gmensdk.key'.format(sdk_dir))
     else:
         generator_node_ca(sdk_dir, agency_dir, 'sdk')
         os.remove('{}/sdk/node.nodeid'.format(sdk_dir))
         shutil.copyfile('{}/sdk/node.crt'.format(sdk_dir),
-                '{}/sdk/sdk.crt'.format(sdk_dir))
+                        '{}/sdk/sdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/node.key'.format(sdk_dir),
-                '{}/sdk/sdk.key'.format(sdk_dir))
+                        '{}/sdk/sdk.key'.format(sdk_dir))
+
 
 def generator_agent_key_csr(_dir, agent):
     """[generate agency cert]

--- a/pys/tool/ca.py
+++ b/pys/tool/ca.py
@@ -199,3 +199,43 @@ def generator_sdk_ca(_dir, agent):
                 '{}/sdk/sdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/node.key'.format(sdk_dir),
                 '{}/sdk/sdk.key'.format(sdk_dir))
+
+def generator_agent_key_csr(_dir, agent):
+    """[generate agency cert]
+    Arguments:
+        dir {[path]} -- [agency cert path]
+        agent {[string]} -- [agency name]
+    """
+    try:
+        agency_dir = os.path.abspath(_dir)
+        if utils.Status.gm_option:
+            os.chdir('{}/scripts/gm/'.format(path.get_path()))
+            (status, result) = utils.getstatusoutput('./cts.sh'
+                                                     ' gen_agency_key_csr {}/{}'
+                                                     .format(agency_dir, agent))
+            os.chdir('{}'.format(path.get_path()))
+        else:
+            os.chdir('{}/scripts'.format(path.get_path()))
+            (status, result) = utils.getstatusoutput('./cts.sh'
+                                                     ' gen_agency_key_csr {}/{}'
+                                                     .format(agency_dir, agent))
+            os.chdir('{}'.format(path.get_path()))
+        if not bool(status):
+            LOGGER.info(' Generate %s cert successful! dir is %s/%s.',
+                        agent, agency_dir, agent)
+        else:
+            # console_error(
+            #     '  Generate cert failed! Please check your network,'
+            #     ' and try to check your opennssl version.')
+            LOGGER.error('  Generate %s cert failed! Result is %s',
+                         agent, result)
+            raise MCError(' Generate %s cert failed! Result is %s' %
+                          (agent, result))
+    except MCError as cert_exp:
+        console_error('  %s ' % cert_exp)
+    except Exception as gen_cert_exp:
+        console_error(
+            '  Generate agency cert failed! excepion is %s.' % gen_cert_exp)
+        LOGGER.error('  Generate agency cert failed! Result is %s', result)
+        raise MCError(
+            'Generate agency agency failed! Result is %s' % gen_cert_exp)

--- a/pys/tool/ca.py
+++ b/pys/tool/ca.py
@@ -113,15 +113,15 @@ def generator_node_ca(_dir, agent, node):
             os.chdir('{}/scripts/gm/'.format(path.get_path()))
             (status, result) = utils.getstatusoutput('./cts.sh'
                                                      ' gen_node_cert {} {}/{}'
-            .format(
-                agent, node_dir, node))
+                                                     .format(
+                                                         agent, node_dir, node))
             os.chdir('{}'.format(path.get_path()))
         else:
             os.chdir('{}/scripts/'.format(path.get_path()))
             (status, result) = utils.getstatusoutput('./cts.sh'
                                                      ' gen_node_cert {} {}/{}'
-            .format(
-                agent, node_dir, node))
+                                                     .format(
+                                                         agent, node_dir, node))
             os.chdir('{}'.format(path.get_path()))
         if not bool(status):
             LOGGER.info(' Generate %s cert successful! dir is %s/%s.',
@@ -130,13 +130,13 @@ def generator_node_ca(_dir, agent, node):
             if utils.Status.gm_option:
                 (status, result) = utils.getstatusoutput('cat {}/{}/gmagency.crt '
                                                          '>> {}/{}/gmnode.crt'.format(
-                    _dir, node, _dir, node))
+                                                             _dir, node, _dir, node))
                 os.remove('{}/{}/gmagency.crt'.format(_dir, node))
                 os.remove('{}/{}/gmnode.serial'.format(_dir, node))
             else:
                 (status, result) = utils.getstatusoutput('cat {}/{}/agency.crt '
                                                          '>> {}/{}/node.crt'.format(
-                    _dir, node, _dir, node))
+                                                             _dir, node, _dir, node))
                 os.remove('{}/{}/agency.crt'.format(_dir, node))
                 os.remove('{}/{}/node.ca'.format(_dir, node))
                 os.remove('{}/{}/node.json'.format(_dir, node))
@@ -178,27 +178,27 @@ def generator_sdk_ca(_dir, agent):
             generator_node_ca(sdk_dir, agency_dir, 'sdk')
             os.remove('{}/sdk/node.nodeid'.format(sdk_dir))
             shutil.copyfile('{}/sdk/node.crt'.format(sdk_dir),
-                            '{}/sdk/sdk.crt'.format(sdk_dir))
+                    '{}/sdk/sdk.crt'.format(sdk_dir))
             shutil.copyfile('{}/sdk/node.key'.format(sdk_dir),
-                            '{}/sdk/sdk.key'.format(sdk_dir))
+                    '{}/sdk/sdk.key'.format(sdk_dir))
             utils.set_gm()
         generator_node_ca('{}/sdk'.format(sdk_dir), agency_dir, 'gm')
         os.remove('{}/sdk/gm/gmnode.nodeid'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmnode.crt'.format(sdk_dir),
-                        '{}/sdk/gm/gmsdk.crt'.format(sdk_dir))
+                '{}/sdk/gm/gmsdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmnode.key'.format(sdk_dir),
-                        '{}/sdk/gm/gmsdk.key'.format(sdk_dir))
+                '{}/sdk/gm/gmsdk.key'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmennode.crt'.format(sdk_dir),
-                        '{}/sdk/gm/gmensdk.crt'.format(sdk_dir))
+                '{}/sdk/gm/gmensdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/gm/gmennode.key'.format(sdk_dir),
-                        '{}/sdk/gm/gmensdk.key'.format(sdk_dir))
+                '{}/sdk/gm/gmensdk.key'.format(sdk_dir))
     else:
         generator_node_ca(sdk_dir, agency_dir, 'sdk')
         os.remove('{}/sdk/node.nodeid'.format(sdk_dir))
         shutil.copyfile('{}/sdk/node.crt'.format(sdk_dir),
-                        '{}/sdk/sdk.crt'.format(sdk_dir))
+                '{}/sdk/sdk.crt'.format(sdk_dir))
         shutil.copyfile('{}/sdk/node.key'.format(sdk_dir),
-                        '{}/sdk/sdk.key'.format(sdk_dir))
+                '{}/sdk/sdk.key'.format(sdk_dir))
 
 
 def generator_agent_key_csr(_dir, agent):

--- a/pys/tool/ca.py
+++ b/pys/tool/ca.py
@@ -222,21 +222,60 @@ def generator_agent_key_csr(_dir, agent):
                                                      .format(agency_dir, agent))
             os.chdir('{}'.format(path.get_path()))
         if not bool(status):
-            LOGGER.info(' Generate %s cert successful! dir is %s/%s.',
+            LOGGER.info(' Generate %s key&csr successful! dir is %s/%s.',
                         agent, agency_dir, agent)
         else:
             # console_error(
             #     '  Generate cert failed! Please check your network,'
             #     ' and try to check your opennssl version.')
-            LOGGER.error('  Generate %s cert failed! Result is %s',
+            LOGGER.error('  Generate %s key&csr failed! Result is %s',
                          agent, result)
-            raise MCError(' Generate %s cert failed! Result is %s' %
+            raise MCError(' Generate %s key&csr failed! Result is %s' %
                           (agent, result))
     except MCError as cert_exp:
         console_error('  %s ' % cert_exp)
     except Exception as gen_cert_exp:
         console_error(
-            '  Generate agency cert failed! excepion is %s.' % gen_cert_exp)
-        LOGGER.error('  Generate agency cert failed! Result is %s', result)
+            '  Generate agency key&csr failed! excepion is %s.' % gen_cert_exp)
+        LOGGER.error('  Generate agency key&csr failed! Result is %s', result)
         raise MCError(
-            'Generate agency agency failed! Result is %s' % gen_cert_exp)
+            'Generate agency key&csr failed! Result is %s' % gen_cert_exp)
+
+
+def sign_agent_cert(_dir, agent_path):
+    """[generate agency cert]
+    Arguments:
+        dir {[path]} -- [ca cert path]
+        agent_path {[string]} -- [agency cert output path]
+    """
+    try:
+        ca_dir = os.path.abspath(_dir)
+        if utils.Status.gm_option:
+            os.chdir('{}/scripts/gm/'.format(path.get_path()))
+            (status, result) = utils.getstatusoutput('./cts.sh'
+                                                     ' sign_agency_cert {} {}'
+                                                     .format(ca_dir, agent_path))
+            os.chdir('{}'.format(path.get_path()))
+        else:
+            os.chdir('{}/scripts'.format(path.get_path()))
+            (status, result) = utils.getstatusoutput('./cts.sh'
+                                                     ' sign_agency_cert {} {}'
+                                                     .format(ca_dir, agent_path))
+            os.chdir('{}'.format(path.get_path()))
+        if bool(status):
+            LOGGER.error(
+                ' cts.sh failed! status is %d, output is %s, dir is %s.', status, result, ca_dir)
+            raise MCError('cts.sh failed! status is %d, output is %s, dir is %s.' % (
+                status, result, ca_dir))
+        LOGGER.info(
+            ' cts.sh success! status is %d, output is %s, dir is %s.', status, result, ca_dir)
+        LOGGER.info(' Sign agency cert success, dir is %s', ca_dir)
+        CONSOLER.info(' Sign agency cert success, dir is %s', ca_dir)
+    except MCError as cert_exp:
+        console_error('  %s ' % cert_exp)
+    except Exception as gen_cert_exp:
+        console_error(
+            '  Sign agency cert failed! excepion is %s.' % gen_cert_exp)
+        LOGGER.error('  Sign agency cert failed! Result is %s', result)
+        raise MCError(
+            'Sign agency cert failed! Result is %s' % gen_cert_exp)

--- a/scripts/cts.sh
+++ b/scripts/cts.sh
@@ -232,15 +232,15 @@ gen_chain_cert)
 gen_agency_cert)
     gen_agency_cert "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
     ;;
-sign_agency_cert)
-    sign_agency_cert "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
-    ;;
 gen_node_cert)
     gen_node_cert "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
     ;;
 gen_agency_key_csr)
   gen_agency_key_csr "$2"
   ;;
+sign_agency_cert)
+    sign_agency_cert "$2" "$3"
+    ;;
 help)
     usage
     ;;

--- a/scripts/cts.sh
+++ b/scripts/cts.sh
@@ -98,6 +98,8 @@ gen_agency_key_csr() {
     openssl genpkey -paramfile "$agencydir/secp256k1.param" -out "$agencydir/agency.key" 2> /dev/null
     openssl req -new -sha256 -subj "/CN=$name/O=fisco-bcos/OU=agency" -key "$agencydir/agency.key" -config "${SHELL_FOLDER}/cert.cnf" -out "$agencydir/agency.csr" 2> /dev/null
 
+    rm -f "$agencydir/secp256k1.param"
+
     echo "build $name agency cert key&csr successful!"
 }
 

--- a/scripts/cts.sh
+++ b/scripts/cts.sh
@@ -238,6 +238,9 @@ sign_agency_cert)
 gen_node_cert)
     gen_node_cert "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
     ;;
+gen_agency_key_csr)
+  gen_agency_key_csr "$2"
+  ;;
 help)
     usage
     ;;

--- a/scripts/cts.sh
+++ b/scripts/cts.sh
@@ -84,6 +84,43 @@ gen_chain_cert() {
     fi
 }
 
+# 生成机构证书key,csr文件
+gen_agency_key_csr() {
+    agencypath="$1"
+    name=$(getname "$agencypath")
+
+    check_name agency "$name"
+    agencydir=$agencypath
+    dir_must_not_exists "$agencydir"
+    mkdir -p $agencydir
+
+    openssl ecparam -out "$agencydir/secp256k1.param" -name secp256k1 2> /dev/null
+    openssl genpkey -paramfile "$agencydir/secp256k1.param" -out "$agencydir/agency.key" 2> /dev/null
+    openssl req -new -sha256 -subj "/CN=$name/O=fisco-bcos/OU=agency" -key "$agencydir/agency.key" -config "${SHELL_FOLDER}/cert.cnf" -out "$agencydir/agency.csr" 2> /dev/null
+
+    echo "build $name agency cert key&csr successful!"
+}
+
+# 签发agency证书
+sign_agency_cert() {
+    chain="$1"
+    agencypath="$2"
+    name=$(getname "$agencypath")
+
+    dir_must_exists "$chain"
+    file_must_exists "$chain/ca.key"
+    check_name agency "$name"
+    agencydir=$agencypath
+    dir_must_exists "$agencydir"
+
+    openssl x509 -req -days 3650 -sha256 -CA "$chain/ca.crt" -CAkey "$chain/ca.key" -CAcreateserial\
+            -in "$agencydir/agency.csr" -out "$agencydir/agency.crt"  -extensions v4_req -extfile "${SHELL_FOLDER}/cert.cnf" 2> /dev/null
+    cp $chain/ca.crt $agencydir/
+    rm -f "$agencydir/agency.csr"
+
+    echo "sign $name agency cert successful!"
+}
+
 gen_agency_cert() {
     chain="$1"
     agencypath="$2"

--- a/scripts/gm/cts.sh
+++ b/scripts/gm/cts.sh
@@ -254,6 +254,9 @@ gen_agency_cert)
 gen_node_cert)
     gen_node_cert "$1" "$2" "$3" "$4" "$5" "$6" "$7" "$8" "$9"
     ;;
+gen_agency_key_csr)
+  gen_agency_key_csr "$2"
+  ;;
 download_tassl)
     check_and_install_tassl
     ;;

--- a/scripts/gm/cts.sh
+++ b/scripts/gm/cts.sh
@@ -139,8 +139,8 @@ gen_agency_key_csr() {
 
 # 签发agency证书
 sign_agency_cert() {
-    chain="$2"
-    agencypath="$3"
+    chain="$1"
+    agencypath="$2"
     name=$(getname "$agencypath")
 
     dir_must_exists "$chain"
@@ -256,6 +256,9 @@ gen_node_cert)
     ;;
 gen_agency_key_csr)
   gen_agency_key_csr "$2"
+  ;;
+sign_agency_cert)
+  sign_agency_cert "$2" "$3"
   ;;
 download_tassl)
     check_and_install_tassl


### PR DESCRIPTION
**command: generate_agency_certificate_key_csr**

|  |  | 
| ---- | ---- |
| Command description | generate agency certificate key and csr file |
| Premise of use | no |
| Parameter setting | path for certificate key, csr file and create agency name | 
| Function | Generate the certificate key and csr file for the CA to issue the certificate |
| Adaptable scenario | agency user needs to create certificate key, csr file |

| | |
| ---- | ---- |
| 命令解释 | 生成联盟链机构证书key和csr文件 |
| 使用前提 | 无 |
| 参数设置 | 文件存放路径和机构名称 |
| 实现功能 | 联盟链机构生成证书key和csr供联盟链管理机构签发机构证书 |
| 适用场景 | 联盟链机构需要基于工具生成上述文件 |

```shell
./generator --generate_agency_certificate_key_csr ./credential agencyA
```

**command: sign_agency_certificate**

| | |
| ---- | ---- |
| Command description | The CA agency issues the agency certificate |
| Premise of use | ca.crt,ca.key exist; agency folder exist and agency.csr exist |
| Parameter setting | path forca.crt,ca.key; path of agency folder  | 
| Function | The CA issues the certificate based on the root certificate through the csr file |
| Adaptable scenario | The CA agency user needs to create agency certificate with csr file |

| | |
| ---- | ---- |
| 命令解释 | 联盟链管理机构签发机构证书 |
| 使用前提 | ca证书、私钥存在；签发机构证书输出路径存在且存在agency.csr文件 |
| 参数设置 | ca根证书、私钥存放路径；机构证书路径 |
| 实现功能 | 联盟链管理机构基于ca根证书，通过机构证书csr文件签发机构证书 |
| 适用场景 | 联盟链机构需要基于工具生成上述文件 |

```shell
./generator --sign_agency_certificate ./credential/ca ./credential/agencyA
```
