### PR TITLE
Update install.sh

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,7 +106,8 @@ install_all_deps() {
     platform=$(echo $?)
     # platform=$(get_platform)
     if [ ${platform} -eq ${Ubuntu_Platform} ]; then
-        sudo apt-get -y install python-pip curl openssl
+        sudo apt-get -y install python3-pip curl openssl
+        sudo ln -sf /usr/bin/pip3 /usr/bin/pip
         # sudo apt-get -y install nc
     elif [ ${platform} -eq ${Centos_Platform} ]; then
         sudo yum install -y python-pip openssl curl which


### PR DESCRIPTION
解释
脚本自动安装了 Python2 和 Python2 的 pip（python-pip），并删除了系统的 python3-pip。 安装完成后，系统中缺失了 pip 命令（因为没有 Python3 的 pip）
脚本在执行 pip 命令时报错：command not found
Python 和 pip 的版本不一致：
Python 是 3.10
pip 不存在
脚本无法正确判断 pip 版本，出现 line 147: not: command not found

报错
./scripts/install.sh: line 129: pip: command not found ./scripts/install.sh: line 130: pip: command not found python and pip is not same version
python -V, get version => 3
Python 3.10.12
pip -V, get version => not
./scripts/install.sh: line 147: not: command not found

环境 ： Ubuntu24